### PR TITLE
Fixes to properly pass server_address to proxy client

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket_client.launch
+++ b/rosbridge_server/launch/rosbridge_websocket_client.launch
@@ -4,7 +4,7 @@
   <arg name="certfile" />
   <arg name="keyfile" />
   <arg name="authenticate" default="false" />
-  
+
   <group if="$(arg ssl)">
     <node name="rosbridge_websocket_client" pkg="rosbridge_server" type="rosbridge_websocket_client" output="screen">
       <param name="certfile" value="$(arg certfile)" />
@@ -17,9 +17,9 @@
   <group unless="$(arg ssl)">
     <node name="rosbridge_websocket_client" pkg="rosbridge_server" type="rosbridge_websocket_client" output="screen">
       <param name="authenticate" value="$(arg authenticate)" />
-      <param name="url" value="$(arg url)"/>
+      <param name="server_address" value="$(arg url)"/>
     </node>
   </group>
-  
+
   <node name="rosapi" pkg="rosapi" type="rosapi" />
 </launch>

--- a/rosbridge_server/scripts/rosbridge_websocket_client.py
+++ b/rosbridge_server/scripts/rosbridge_websocket_client.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         protocol = RosbridgeProtocol(0)
 
         # Connect with server
-        server_address = rospy.get_param("server_address")
+        server_address = rospy.get_param("~server_address")
         ws = WebsocketClientTornado(server_address)
 
 	#ws.send_message("Hola!")


### PR DESCRIPTION
The sample launch file was using the wrong parameter name and the proxy client wasn't properly reading it from the param server
